### PR TITLE
Kick off our application with a POST request instead of GET

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -21,7 +21,7 @@ Route::get(
     '/',
     ['as' => 'approot', 'uses' => 'SurveyController@showFirstSurveyResults']
 );
-Route::get(
+Route::post(
     '/first_survey',
     ['as' => 'survey.first_survey', 'uses' => 'SurveyController@showFirstSurvey']
 );

--- a/readme.md
+++ b/readme.md
@@ -61,8 +61,8 @@ and open a number's configuration by clicking on it.
 ![Open a number configuration](https://raw.github.com/TwilioDevEd/automated-survey-laravel/master/number-conf.png)
 
 Next, edit the "Request URL" field under the "Voice" section and point
-it towards your ngrok-exposed application `/first_survey` route. Set
-the HTTP method to GET. If you have are trying out the Heroku
+it towards your ngrok-exposed application `/first_survey` route. Confirm
+the HTTP method is set to POST. If you have are trying out the Heroku
 application you need to point Twilio to
 `http://<your-app-name>.herokuapp.com/first_survey`. See the image
 below for an example:


### PR DESCRIPTION
The way this application is handling requests was a bit confusing to me. The code is using [RESTful Resource Controllers](http://laravel.com/docs/5.1/controllers#restful-resource-controllers) but the way I naturally think about Twilio interacting with webhooks throughout a call isn't RESTful. As a result questions are being obtained via a GET request but to change that would be a bigger reworking of the code. For this change I just updated the first request to be a POST so the developer isn't switching their webhook within Twilio without a clear reason as to why.
